### PR TITLE
GHA Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       matrix: ${{ steps.cpp-matrix.outputs.matrix }}
     steps:
       - name: Generate Test Matrix
-        uses: cmazakas/cpp-actions/cpp-matrix@899c4275c0a330e40ce41ab5d9ef5821db4482b6
+        uses: alandefreitas/cpp-actions/cpp-matrix@v1.6.1
         id: cpp-matrix
         with:
           compilers: |
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup C++
-        uses: cmazakas/cpp-actions/setup-cpp@899c4275c0a330e40ce41ab5d9ef5821db4482b6
+        uses: alandefreitas/cpp-actions/setup-cpp@v1.6.1
         id: setup-cpp
         with:
           compiler: ${{ matrix.compiler }}
@@ -102,13 +102,13 @@ jobs:
           trace-commands: true
 
       - name: Install packages
-        uses: alandefreitas/cpp-actions/package-install@v1.5.0
+        uses: alandefreitas/cpp-actions/package-install@v1.6.1
         id: package-install
         with:
           apt-get: ${{ matrix.install }}
 
       - name: Clone Boost
-        uses: cmazakas/cpp-actions/boost-clone@899c4275c0a330e40ce41ab5d9ef5821db4482b6
+        uses: alandefreitas/cpp-actions/boost-clone@v1.6.1
         id: boost-clone
         with:
           branch: ${{ (github.ref_name == 'master' && github.ref_name) || 'develop' }}
@@ -150,7 +150,7 @@ jobs:
           cp -r "$workspace_root"/* "libs/$module"
 
       - name: Boost CMake Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.5.0
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.6.1
         with:
           source-dir: ../boost-root
           build-dir: __build_cmake_test__
@@ -173,7 +173,7 @@ jobs:
           ref-source-dir: ../boost-root/libs/buffers
 
       - name: Subdirectory Integration Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.5.0
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.6.1
         with:
           source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
           build-dir: __build_cmake_subdir_test__
@@ -195,7 +195,7 @@ jobs:
         run: echo "$GITHUB_WORKSPACE/.local/bin" >> $GITHUB_PATH
 
       - name: Find Package Integration Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.5.0
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.6.1
         with:
           source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
           build-dir: __build_cmake_install_test__
@@ -213,7 +213,7 @@ jobs:
           ref-source-dir: ../boost-root/libs/buffers/test/cmake_test
 
       - name: Root Project CMake Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.5.0
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.6.1
         with:
           source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}
           build-dir: __build_root_test__
@@ -235,7 +235,7 @@ jobs:
           ref-source-dir: .
 
       - name: Boost B2 Workflow
-        uses: alandefreitas/cpp-actions/b2-workflow@v1.5.0
+        uses: alandefreitas/cpp-actions/b2-workflow@v1.6.1
         with:
           source-dir: ../boost-root
           modules: buffers
@@ -250,7 +250,7 @@ jobs:
           shared: ${{ matrix.shared }}
 
       - name: FlameGraph
-        uses: alandefreitas/cpp-actions/flamegraph@v1.5.0
+        uses: alandefreitas/cpp-actions/flamegraph@v1.6.1
         if: matrix.time-trace
         with:
           source-dir: ../boost-root/libs/buffers
@@ -303,7 +303,7 @@ jobs:
           fetch-depth: 100
 
       - name: Changelog
-        uses: alandefreitas/cpp-actions/create-changelog@v1.5.0
+        uses: alandefreitas/cpp-actions/create-changelog@v1.6.1
         with:
           thank-non-regular: ${{ startsWith(github.ref, 'refs/tags/') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,8 @@ jobs:
           ref-source-dir: ../boost-root/libs/buffers/test/cmake_test
 
       - name: Set Path
-        run: echo "${{ startsWith(matrix.runs-on, 'windows') && '$GITHUB_WORKSPACE/.local/bin' || '' }}" >> $GITHUB_PATH
+        if: startsWith(matrix.runs-on, 'windows') && matrix.shared
+        run: echo "$GITHUB_WORKSPACE/.local/bin" >> $GITHUB_PATH
 
       - name: Find Package Integration Workflow
         uses: alandefreitas/cpp-actions/cmake-workflow@v1.5.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
           cxxflags: ${{ matrix.cxxflags }}
           shared: ${{ matrix.shared }}
           install: false
-          cmake-version: '>=3.11'
+          cmake-version: '>=3.8'
           extra-args: -D BOOST_CI_INSTALL_TEST=OFF
           ref-source-dir: ../boost-root/libs/buffers/test/cmake_test
 
@@ -208,9 +208,8 @@ jobs:
           cxxflags: ${{ matrix.cxxflags }}
           shared: ${{ matrix.shared }}
           install: false
+          cmake-version: '>=3.13'
           extra-args: -D BOOST_CI_INSTALL_TEST=ON -D CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/.local
-          package: false
-          package-artifact: false
           ref-source-dir: ../boost-root/libs/buffers/test/cmake_test
 
       - name: Root Project CMake Workflow
@@ -230,6 +229,7 @@ jobs:
           cxxflags: ${{ matrix.cxxflags }}
           shared: ${{ matrix.shared }}
           extra-args: -D Boost_VERBOSE=ON -D BUILD_TESTING=ON -D BOOST_SRC_DIR="../boost-root"
+          cmake-version: '>=3.8'
           package: false
           package-artifact: false
           ref-source-dir: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
           source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
           build-dir: __build_cmake_subdir_test__
           generator: ${{ matrix.generator }}
-          build-type: ${{ matrix.build_type }}
+          build-type: ${{ matrix.build-type }}
           cxxstd: ${{ matrix.latest-cxxstd }}
           cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
           ccflags: ${{ matrix.ccflags }}

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -12,12 +12,10 @@ project(cmake_subdir_test LANGUAGES CXX)
 set(__ignore__ ${CMAKE_C_COMPILER})
 set(__ignore__ ${CMAKE_C_FLAGS})
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-
 if(BOOST_CI_INSTALL_TEST)
   find_package(Boost CONFIG REQUIRED COMPONENTS buffers)
 else()
-
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
   add_subdirectory(../.. boostorg/buffers)
 
   set(deps


### PR DESCRIPTION
* Manually specify cmake-version because of cmake-3.28-rc segfaulting on osx
* Relocate set(output directory) for add_subdirectory tests only
* fix typo in "build-type"