### PR TITLE
make_buffer supports contiguous containers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ function(boost_buffers_setup_properties target)
         PUBLIC
             Boost::assert
             Boost::config
+            Boost::core
             Boost::static_assert
             Boost::system
         PRIVATE

--- a/include/boost/buffers/make_buffer.hpp
+++ b/include/boost/buffers/make_buffer.hpp
@@ -13,6 +13,8 @@
 #include <boost/buffers/detail/config.hpp>
 #include <boost/buffers/const_buffer.hpp>
 #include <boost/buffers/mutable_buffer.hpp>
+#include <boost/buffers/type_traits.hpp>
+#include <boost/core/data.hpp>
 #include <cstdlib>
 #include <type_traits>
 
@@ -93,6 +95,42 @@ make_buffer(
 {
     return const_buffer(
         data, N * sizeof(T));
+}
+
+/** Return a buffer.
+*/
+template<
+    class T
+#ifndef BOOST_BUFFERS_DOCS
+    , typename std::enable_if<
+        detail::is_mutable_contiguous_container<T>::value,
+        int>::type = 0
+#endif
+>
+mutable_buffer
+make_buffer(T& data)
+{
+    return mutable_buffer(
+        boost::data(data),
+        sizeof(*(data.data())) * data.size());
+}
+
+/** Return a buffer.
+*/
+template<
+    class T
+#ifndef BOOST_BUFFERS_DOCS
+    , typename std::enable_if<
+        detail::is_const_contiguous_container<T>::value,
+        int>::type = 0
+#endif
+>
+const_buffer
+make_buffer(T& data)
+{
+    return const_buffer(
+        boost::data(data),
+        sizeof(*(data.data())) * data.size());
 }
 
 } // buffers

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -23,6 +23,7 @@ else()
 
     assert
     config
+    core
     static_assert
     system
     throw_exception

--- a/test/make_buffer.cpp
+++ b/test/make_buffer.cpp
@@ -10,6 +10,11 @@
 // Test that header file is self-contained.
 #include <boost/buffers/make_buffer.hpp>
 
+#include <boost/core/span.hpp>
+#include <vector>
+#include <memory>
+
+#include "boost/buffers/type_traits.hpp"
 #include "test_suite.hpp"
 
 namespace boost {
@@ -66,6 +71,52 @@ struct make_buffer_test
             const_buffer b = make_buffer(cbuf3);
             BOOST_TEST_EQ(b.data(), cbuf3);
             BOOST_TEST_EQ(b.size(), 3);
+        }
+
+        // make_buffer(T&)
+        {
+            std::vector<int> buf{1, 2, 3, 4};
+            mutable_buffer b = make_buffer(buf);
+            BOOST_TEST_EQ(b.data(), buf.data());
+            BOOST_TEST_EQ(b.size(), sizeof(int) * buf.size());
+
+            boost::span<int> s(buf);
+            mutable_buffer b2 = make_buffer(s);
+            BOOST_TEST_EQ(b2.data(), buf.data());
+            BOOST_TEST_EQ(b2.size(), sizeof(int) * buf.size());
+        }
+        {
+            std::vector<int> const buf{1, 2, 3, 4};
+            const_buffer b = make_buffer(buf);
+            BOOST_TEST_EQ(b.data(), buf.data());
+            BOOST_TEST_EQ(b.size(), sizeof(int) * buf.size());
+
+            boost::span<int const> s(buf);
+            const_buffer b2 = make_buffer(s);
+            BOOST_TEST_EQ(b2.data(), buf.data());
+            BOOST_TEST_EQ(b2.size(), sizeof(int) * buf.size());
+        }
+        {
+            BOOST_TEST(
+                detail::is_mutable_contiguous_container<
+                    std::vector<int>&
+                >::value);
+            BOOST_TEST(
+                !detail::is_const_contiguous_container<
+                    std::vector<int>&
+                >::value);
+            BOOST_TEST(
+                detail::is_const_contiguous_container<
+                    std::vector<int> const&
+                >::value);
+            BOOST_TEST(
+                !detail::is_mutable_contiguous_container<
+                    std::vector<std::unique_ptr<int>>&
+                >::value);
+            BOOST_TEST(
+                !detail::is_const_contiguous_container<
+                    std::vector<std::unique_ptr<int>> const&
+                >::value);
         }
     }
 


### PR DESCRIPTION
If we like the vibe of this PR, we'll update the type traits to essentially be a copy paste of what Core does for `span` and we'll flesh out the test suite with some compile-fail tests as well.